### PR TITLE
Support for up to 1024 plugins, related structure changes support

### DIFF
--- a/Mopy/mash/mosh.py
+++ b/Mopy/mash/mosh.py
@@ -1184,7 +1184,7 @@ class Cell(Record):
                 if isinstance(record, Cell_Frmr):
                     if iMod > 255:
                         out.pack('4si', 'FRMR', 8)
-                        out.write(struct.pack('2i', (iMod, iObj)))
+                        out.write(struct.pack('2i', iMod, iObj))
                     else:
                         out.pack('4si', 'FRMR', 4)
                         out.write(struct.pack('i', iObj)[:3])
@@ -1814,7 +1814,7 @@ class Scpt(Record):
         """Set reference data for a global script."""
         (iMod,iObj) = reference
         if iMod > 255:
-            self.rnam.setData(struct.pack('2i',(iMod,iObj)))
+            self.rnam.setData(struct.pack('2i',iMod,iObj))
         else:
             self.rnam.setData(struct.pack('i',iObj)[:3] + struct.pack('B',iMod))
         self.setChanged()
@@ -6266,7 +6266,7 @@ class FileRefs(FileRep):
         if objRecords and objRecords[0].name == 'MVRF':
             data = cStringIO.StringIO()
             if newIMod > 255:
-                data.write(struct.pack('2i', (newIMod, newIObj)))
+                data.write(struct.pack('2i', newIMod, newIObj))
             else:
                 data.write(struct.pack('i',newIObj)[:3])
                 data.write(struct.pack('B',newIMod))

--- a/Mopy/mash/mosh.py
+++ b/Mopy/mash/mosh.py
@@ -1182,9 +1182,13 @@ class Cell(Record):
             for record in objRecords:
                 #--FRMR/NAME placeholder?
                 if isinstance(record, Cell_Frmr):
-                    out.pack('4si','FRMR',4)
-                    out.write(struct.pack('i',iObj)[:3])
-                    out.pack('B',iMod)
+                    if iMod > 255:
+                        out.pack('4si', 'FRMR', 8)
+                        out.write(struct.pack('2i', (iMod, iObj)))
+                    else:
+                        out.pack('4si', 'FRMR', 4)
+                        out.write(struct.pack('i', iObj)[:3])
+                        out.pack('B', iMod)
                     out.packSub0('NAME',objId)
                 else:
                     record.getSize()

--- a/Mopy/mash/mosh.py
+++ b/Mopy/mash/mosh.py
@@ -6265,8 +6265,11 @@ class FileRefs(FileRep):
         newObject = (newIMod,newIObj)+object[2:]
         if objRecords and objRecords[0].name == 'MVRF':
             data = cStringIO.StringIO()
-            data.write(struct.pack('i',newIObj)[:3])
-            data.write(struct.pack('B',newIMod))
+            if newIMod > 255:
+                data.write(struct.pack('2i', (newIMod, newIObj)))
+            else:
+                data.write(struct.pack('i',newIObj)[:3])
+                data.write(struct.pack('B',newIMod))
             objRecords[0].data = data.getvalue()
             objRecords[0].setChanged(False)
             data.close()

--- a/Mopy/mash/mosh.py
+++ b/Mopy/mash/mosh.py
@@ -2342,7 +2342,7 @@ class MWIniFile:  # Polemos: OpenMW/TES3mp support
                 if maLoadPluginFiles:
                     plugin = maLoadPluginFiles.group(1).rstrip()
                     loadPluginPath, loadPluginExt = self.getSrcFilePathInfo(plugin), self.getExt(plugin)
-                    if len(self.loadFiles) == 255: self.loadFilesExtra.append(plugin)
+                    if len(self.loadFiles) == 1023: self.loadFilesExtra.append(plugin)
                     elif loadPluginPath and re.match('^\.es[pm]$', loadPluginExt): self.loadFiles.append(plugin)
                     else: self.loadFilesBad.append(plugin)
 
@@ -2651,8 +2651,8 @@ class MWIniFile:  # Polemos: OpenMW/TES3mp support
         """Load only if morrowind.ini/openmw.cfg has changed."""
         hasChanged = self.hasChanged()
         if hasChanged: self.loadConf()
-        if len(self.loadFiles) > 255:
-            del self.loadFiles[255:]
+        if len(self.loadFiles) > 1023:
+            del self.loadFiles[1023:]
             self.safeSave()
         return hasChanged
 
@@ -2702,7 +2702,7 @@ class MWIniFile:  # Polemos: OpenMW/TES3mp support
 
     def isMaxLoaded(self):
         """True if load list is full."""
-        return len(self.loadFiles) >= 255
+        return len(self.loadFiles) >= 1023
 
     def isLoaded(self,modFile):
         """True if modFile is in load list."""


### PR DESCRIPTION
This builds off of the work of #3. To support more than 256 plugins, MWSE has to change how ref IDs are stored in a few places. If these records are 4 bytes, it's from a mod with an index <= 255, while if it is >255 it saves in an 8-byte variant.

We've been tested this on the Morrowind Modding Community discord, though none of us are hugely familiar with Mash's codebase.

This feature is still in testing, and any feedback related to Mash support or other pain points would be appreciated.

Affected records: CELL.FRMR, CELL.MVRF, REFR.FRMR, SCPT.RNAM