### PR TITLE
Allow Sync to Masters to use more than 255 plugins.

### DIFF
--- a/Mopy/mash/masher.py
+++ b/Mopy/mash/masher.py
@@ -1172,7 +1172,7 @@ class MasterList(gui.List):
         #--Already selected?
         if self.isLoaded(masterInfos): return True
         #--Already at max masters?
-        elif len(self.newMasters) == 255:
+        elif len(self.newMasters) == mosh.mwIniFile.maxPlugins:
             gui.dialog.ErrorMessage(self, _(u'Unable to select %s because file already has maximum number of masters.') % (masterName,))
             return False
         #--New master?


### PR DESCRIPTION
There was another hardcoded 255 check in `MasterList.load` that we missed. Sync to Load List makes use of this.